### PR TITLE
docs(README): fix before example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,22 +56,18 @@ const MyComponent = ({ filter }) => {
 
   useEffect(() => {
     let isCanceled = false;
-    let isFetchPending = false;
+    const controller = new AbortController();
 
     const runHandler = async () => {
-      const controller = new AbortController();
       try {
-        isFetchPending = true;
         const data = await fetch("/data?filter=" + filter, {
           signal: controller.signal
         }).then(res => res.json());
-        isFetchPending = false;
         if (isCanceled) {
           return;
         }
         setData(data);
       } catch (err) {
-        isFetchPending = false;
         if (err.name === "AbortError") {
           return;
         }
@@ -82,9 +78,7 @@ const MyComponent = ({ filter }) => {
     runHandler();
     return () => {
       isCanceled = true;
-      if (isFetchPending) {
-        controller.abort();
-      }
+      controller.abort();
     };
   }, [setData]);
 };


### PR DESCRIPTION
According to https://developers.google.com/web/updates/2017/09/abortable-fetch

> Note: It's ok to call .abort() after the fetch has already completed, fetch simply ignores it.