### PR TITLE
fix: change Iterator return type to fix compilation error

### DIFF
--- a/src/use-async-effect.ts
+++ b/src/use-async-effect.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 
-const noop = () => {};
+const noop = () => { };
 
 export const useAsyncEffect = (
   createGenerator: (
@@ -9,7 +9,7 @@ export const useAsyncEffect = (
       onCancelError?: null | ((err: Error) => void)
     ) => void
   ) => // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  IterableIterator<any>,
+    Iterator<any, any, any>,
   deps: React.DependencyList
 ) => {
   const generatorRef = useRef(createGenerator);


### PR DESCRIPTION
## Description

Changed `IterableIterator<any>` to `Iterator<any, any, any>` to address an invalid compilation issues.

## Related Issue

#28 shows a case where compilation fails.

## Motivation and Context

The code prior to this change would not compile in some valid cases. This change seems to allow compilation is all valid cases.

## How Has This Been Tested?

I ran the new code against a failing case, and it compiles fine now.
