### PR TITLE
feat: Make dependency list optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ function useAsyncEffect(
     ) => void,
     cast: <T>(promise: Promise<T>) => Generator<Promise<T>, T>
   ) => Iterator<any, any, any>,
-  deps: React.DependencyList
+  deps?: React.DependencyList
 ): void;
 ```
 

--- a/src/use-async-effect.spec.tsx
+++ b/src/use-async-effect.spec.tsx
@@ -50,6 +50,33 @@ it("calls the generator again once a dependency changes", () => {
   expect(callable).toHaveBeenCalledTimes(2);
 });
 
+
+it("calls the generator on each render if no dependency list given", () => {
+  const callable = jest.fn();
+
+  let setState = (() => undefined) as (str: string) => void;
+
+  const TestComponent: React.FC = () => {
+    const [, _setState] = React.useState<string>("hello");
+    useAsyncEffect(function* () {
+      callable();
+    });
+    setState = _setState;
+    return null;
+  };
+
+  render(<TestComponent />);
+
+  act(() => {
+    setState("aye");
+  });
+  act(() => {
+    setState("bye");
+  });
+
+  expect(callable).toHaveBeenCalledTimes(3);
+});
+
 it("yield can resolve a non promise object", () => {
   const callable = jest.fn();
 

--- a/src/use-async-effect.ts
+++ b/src/use-async-effect.ts
@@ -19,7 +19,7 @@ export const useAsyncEffect = (
     ) => void,
     cast: <T>(promise: Promise<T>) => Generator<Promise<T>, T>
   ) => Iterator<unknown, GeneratorReturnValueType>,
-  deps: React.DependencyList
+  deps?: React.DependencyList
 ): void => {
   const generatorRef = useRef(createGenerator);
 


### PR DESCRIPTION
The dependency list is optional in the React useEffect hook

resolves #130 